### PR TITLE
Add missing params in @signed_params

### DIFF
--- a/lib/ex_cloudinary/client.ex
+++ b/lib/ex_cloudinary/client.ex
@@ -3,7 +3,11 @@ defmodule ExCloudinary.Client do
   use HTTPoison.Base
   @after_compile __MODULE__
   @base_url ~S(https://api.cloudinary.com/v1_1)
-  @signed_params ~w(callback eager format from_public_id public_id tags timestamp to_public_id text transformation type)a
+  @signed_params ~w(callback eager eager_async format from_public_id public_id
+    resource_type tags timestamp to_public_id text transformation type context allowed_formats proxy
+    notification_url eager_notification_url backup return_delete_token faces exif colors image_metadata phash
+    invalidate use_filename unique_filename folder overwrite discard_original_filename face_coordinates
+    custom_coordinates raw_convert auto_tagging background_removal moderation upload_preset)a
   @cloud_name Application.get_env(:ex_cloudinary, :cloud_name)
   @api_key Application.get_env(:ex_cloudinary, :api_key)
   @api_secret Application.get_env(:ex_cloudinary, :api_secret, <<0>>)


### PR DESCRIPTION
Include in `@signed_params` attribute the keys of Keyword list of options used in `upload_image/2`.
Without it an exception is raised:

```
ExCloudinary.upload_image("/path/to/image.jpeg", [use_filename: "true"])
```

```
%HTTPoison.Response{body: "{\"error\":{\"message\":\"Invalid Signature 48a91ebccf4447094d1b614ab30f831925720abf. String to sign - 'timestamp=1463590187&use_filename=true'.\"}}",
 headers: [{"Cache-Control", "no-cache"},
  {"Content-Type", "application/json; charset=utf-8"},
  {"Date", "Wed, 18 May 2016 16:49:57 GMT"}, {"Server", "cloudinary"},
  {"Status", "401 Unauthorized"},
  {"X-Cld-Error",
   "Invalid Signature 48a91ebccf4447094d1b614ab30f831925720abf. String to sign - 'timestamp=1463590187&use_filename=true'."},
  {"X-Request-Id", "6a16828018cc7eca"}, {"X-UA-Compatible", "IE=Edge,chrome=1"},
  {"transfer-encoding", "chunked"}, {"Connection", "keep-alive"}],
 status_code: 401}
```
